### PR TITLE
Script to enable copy code button on all code snippets

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -43,4 +43,5 @@
     {%- include footer-scripts.html -%}
     
   </body>
+  <script src="/assets/js/copy-code.js"></script>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -37,29 +37,31 @@ pre.highlight > code {
     padding-left: 0;
 }
 pre.highlight.highlight {
-    /* border-left: 15px solid #35383c; */
-    /* color: #c1c2c3; */
     overflow: auto;
     white-space: pre;
     word-wrap: normal;
 }
-pre.highlight.highlight, pre.highlight.highlight code {
-    background-color: #222;
-}
-pre.highlight .copy {
-    color: white;
-    position: absolute;
-    right: 1.2rem;
-    top: 0.5rem;
+pre.highlight .copy-button {
+    height: 22px;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 11px;
+    font-weight: 500;
     opacity: 0;
+    pointer-events: all;
+    text-transform: uppercase;
+    letter-spacing: 0.7px;
+    padding: 2px 5px;
+    border-radius: 5px;
+    background-color: #222222;
+    transition: opacity 0.2s, background-color 0.2s;
+    font-family: "Sora", sans-serif;
 }
-pre.highlight .copy:active, pre.highlight .copy:focus, pre.highlight .copy:hover {
-    background: rgba(0, 0, 0, 0.7);
+pre.highlight:active .copy-button, pre.highlight:focus .copy-button, pre.highlight:hover .copy-button {
     opacity: 1;
 }
-pre.highlight:active .copy, pre.highlight:focus .copy, pre.highlight:hover .copy {
-    background: rgba(0, 0, 0, 0.7);
+pre.highlight .copy-button:active, pre.highlight .copy-button:focus, pre.highlight .copy-button:hover {
     opacity: 1;
+    background-color: #333333;
 }
 
 /* Custom styles above this line */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -24,6 +24,44 @@
 .max-h-select {
     max-height: 300px;
 }
+
+/** * Codeblock. */
+pre.highlight {
+    padding: 8px 12px;
+    position: relative;
+}
+pre.highlight > code {
+    border: 0;
+    overflow-x: auto;
+    padding-right: 0;
+    padding-left: 0;
+}
+pre.highlight.highlight {
+    /* border-left: 15px solid #35383c; */
+    /* color: #c1c2c3; */
+    overflow: auto;
+    white-space: pre;
+    word-wrap: normal;
+}
+pre.highlight.highlight, pre.highlight.highlight code {
+    background-color: #222;
+}
+pre.highlight .copy {
+    color: white;
+    position: absolute;
+    right: 1.2rem;
+    top: 0.5rem;
+    opacity: 0;
+}
+pre.highlight .copy:active, pre.highlight .copy:focus, pre.highlight .copy:hover {
+    background: rgba(0, 0, 0, 0.7);
+    opacity: 1;
+}
+pre.highlight:active .copy, pre.highlight:focus .copy, pre.highlight:hover .copy {
+    background: rgba(0, 0, 0, 0.7);
+    opacity: 1;
+}
+
 /* Custom styles above this line */
 
 @tailwind utilities;

--- a/assets/css/syntax.css
+++ b/assets/css/syntax.css
@@ -1,5 +1,5 @@
-.highlight pre { background-color: #272822; }
-.highlight .hll { background-color: #272822; }
+.highlight pre { background-color: #222222; }
+.highlight .hll { background-color: #222222; }
 .highlight .c { color: #75715e } /* Comment */
 .highlight .err { color: #960050; background-color: #1e0010 } /* Error */
 .highlight .k { color: #66d9ef } /* Keyword */

--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -1,0 +1,63 @@
+
+// inserts the copy code button in the top right corner and is enabled on hover
+var codeBlocks = document.querySelectorAll('pre.highlight');
+codeBlocks.forEach(function (codeBlock) {
+  var copyButton = document.createElement('button');
+  copyButton.className = 'copy';
+  copyButton.type = 'button';
+  copyButton.ariaLabel = 'Copy code to clipboard';
+  copyButton.innerText = 'Copy';
+
+  codeBlock.append(copyButton);
+
+  copyButton.addEventListener('click', function () {
+    var code = codeBlock.querySelector('code').innerText.trim();
+    window.navigator.clipboard.writeText(code);
+
+    copyButton.innerText = 'Copied';
+    var fourSeconds = 4000;
+
+    setTimeout(function () {
+      copyButton.innerText = 'Copy';
+    }, fourSeconds);
+  });
+});
+
+// inserts the copy code button below the code block
+/* const copyToClipboardButtonStrings = {
+  default: 'Copy',
+  ariaLabel: 'Copy to clipboard',
+  copied: 'Copied',
+};
+
+const copyableCodeBlocks = document.querySelectorAll('pre.highlight');
+copyableCodeBlocks.forEach((codeBlock) => {
+  console.log("In code block")  
+  const code = codeBlock.innerText;
+
+  const copyCodeButton = document.createElement('button');
+  copyCodeButton.className = 'copy-code-button bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded';
+  copyCodeButton.innerText = copyToClipboardButtonStrings.default;
+  copyCodeButton.setAttribute('aria-label', copyToClipboardButtonStrings.ariaLabel);
+  copyCodeButton.type = 'button';
+  codeBlock.parentElement.append(copyCodeButton);
+
+  // Accessible alert whose inner text changes when we copy.
+  const copiedAlert = document.createElement('span');
+  copiedAlert.setAttribute('role', 'alert');
+  copiedAlert.classList.add('screen-reader-only');
+  codeBlock.parentElement.append(copiedAlert);
+
+  copyCodeButton.addEventListener('click', () => {
+    window.navigator.clipboard.writeText(code);
+    copyCodeButton.classList.add('copied');
+    copyCodeButton.innerText = copyToClipboardButtonStrings.copied;
+    copiedAlert.innerText = copyToClipboardButtonStrings.copied;
+
+    setTimeout(() => {
+      copyCodeButton.classList.remove('copied');
+      copyCodeButton.innerText = copyToClipboardButtonStrings.default;
+      copiedAlert.innerText = '';
+    }, 2000);
+  });
+}); */

--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -1,63 +1,42 @@
 
+var setCopyButtonContent = function(copyButton) {
+  if (!copyButton) {
+    return;
+  }
+
+  var copyIcon = document.createElement('i');
+  copyIcon.classList.add('copy-icon', 'fa-classic', 'fa-copy', 'w-[10px]', 'h-[10px]', 'text-white/70', 'mr-1');
+  copyButton.innerText = 'Copy';
+  copyButton.prepend(copyIcon);
+}
+
 // inserts the copy code button in the top right corner and is enabled on hover
 var codeBlocks = document.querySelectorAll('pre.highlight');
 codeBlocks.forEach(function (codeBlock) {
+  var copyContainer = document.createElement('div');
+  copyContainer.classList.add('copy-container', 'sticky', 'overflow-visible', 'top-0', 'left-0', 'w-full', 'h-0', 'flex', 'justify-end', 'pointer-events-none', 'bg-transparent');
+
   var copyButton = document.createElement('button');
-  copyButton.className = 'copy';
+
+  copyButton.classList.add('copy-button');
   copyButton.type = 'button';
   copyButton.ariaLabel = 'Copy code to clipboard';
-  copyButton.innerText = 'Copy';
 
-  codeBlock.append(copyButton);
+  setCopyButtonContent(copyButton);
+
+  copyContainer.append(copyButton);
+  codeBlock.prepend(copyContainer);
 
   copyButton.addEventListener('click', function () {
     var code = codeBlock.querySelector('code').innerText.trim();
     window.navigator.clipboard.writeText(code);
 
     copyButton.innerText = 'Copied';
-    var fourSeconds = 4000;
+    var threeSeconds = 3000;
 
     setTimeout(function () {
-      copyButton.innerText = 'Copy';
-    }, fourSeconds);
+      setCopyButtonContent(copyButton);
+      copyButton.blur();
+    }, threeSeconds);
   });
 });
-
-// inserts the copy code button below the code block
-/* const copyToClipboardButtonStrings = {
-  default: 'Copy',
-  ariaLabel: 'Copy to clipboard',
-  copied: 'Copied',
-};
-
-const copyableCodeBlocks = document.querySelectorAll('pre.highlight');
-copyableCodeBlocks.forEach((codeBlock) => {
-  console.log("In code block")  
-  const code = codeBlock.innerText;
-
-  const copyCodeButton = document.createElement('button');
-  copyCodeButton.className = 'copy-code-button bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded';
-  copyCodeButton.innerText = copyToClipboardButtonStrings.default;
-  copyCodeButton.setAttribute('aria-label', copyToClipboardButtonStrings.ariaLabel);
-  copyCodeButton.type = 'button';
-  codeBlock.parentElement.append(copyCodeButton);
-
-  // Accessible alert whose inner text changes when we copy.
-  const copiedAlert = document.createElement('span');
-  copiedAlert.setAttribute('role', 'alert');
-  copiedAlert.classList.add('screen-reader-only');
-  codeBlock.parentElement.append(copiedAlert);
-
-  copyCodeButton.addEventListener('click', () => {
-    window.navigator.clipboard.writeText(code);
-    copyCodeButton.classList.add('copied');
-    copyCodeButton.innerText = copyToClipboardButtonStrings.copied;
-    copiedAlert.innerText = copyToClipboardButtonStrings.copied;
-
-    setTimeout(() => {
-      copyCodeButton.classList.remove('copied');
-      copyCodeButton.innerText = copyToClipboardButtonStrings.default;
-      copiedAlert.innerText = '';
-    }, 2000);
-  });
-}); */


### PR DESCRIPTION
- The copy button here is enabled on hover
- The styling might not be great, might need work
-  The copy button doesn't look good when the top line in the code snippet is long, it is displayed on top of the code