### PR TITLE
Made package and import format in code snippets consistent

### DIFF
--- a/src/_java-server-devguide/2.3-hello-world.md
+++ b/src/_java-server-devguide/2.3-hello-world.md
@@ -48,7 +48,6 @@ _File: src/main/java/tutorial/MainPlane.java_
 
 ```java
 package tutorial;
-
 import swim.api.plane.AbstractPlane;
 import swim.kernel.Kernel;
 import swim.server.ServerLoader;

--- a/src/_java-server-devguide/2.5-hello-lane.md
+++ b/src/_java-server-devguide/2.5-hello-lane.md
@@ -22,6 +22,7 @@ Let's add the most basic form of a lane - a command lane - to the `Agent` class 
 _File: src/main/java/tutorial/Agent.java_
 
 ```java
+package tutorial;
 import swim.api.SwimLane;
 import swim.api.agent.AbstractAgent;
 import swim.api.lane.CommandLane;


### PR DESCRIPTION
Made all the code snippets uniform, where the whole class is contained in a code snippet include the `package` statement above imports.